### PR TITLE
Fixed url config

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -1,6 +1,6 @@
 {
   "basepath": "/",
-  "url": "https://hoverboard-dev.web.app/",
+  "url": "https://androidmakers.fr/",
   "analytics": "UA-43643469-8",
   "prefix": "/",
   "googleMapApiKey": "AIzaSyAKOkGjmfBPTuYlDyPxlrSj7H-1oqWET7E"

--- a/config/production.json
+++ b/config/production.json
@@ -1,6 +1,6 @@
 {
   "basepath": "/",
-  "url": "https://hoverboard-master.web.app/",
+  "url": "https://androidmakers.fr/",
   "analytics": "UA-43643469-9",
   "prefix": "/",
   "googleMapApiKey": "AIzaSyCJqlRVGIe6bfU43rga3cnK7tSXXwc7JD8"


### PR DESCRIPTION
Tentative fix for:
<img width="414" alt="Screenshot 2022-02-10 at 13 52 12" src="https://user-images.githubusercontent.com/2204411/153412216-178507c3-3094-4dea-aac7-805a50761638.png">

**Problem**
 
https://androidmakers.fr/ 
source code contains images such as:
`<meta content="https://hoverboard-master.web.app/images/social-share.jpg" itemprop="image">`
This is why it display the hoverboard image.

So even if we already changed `images/social-share.jpg` locally, as it takes the `hoverboard-master.web.app` url, it doesn't take ours.

**Solution**

There is two potential fix:
1. Within `Data/resources.json`, replace `"image": "images/social-share.jpg",` by starting with a slash: `"image": "/images/social-share.jpg",`
2. Identify where this `hoverboard-master.web.app` url is coming from. It is referenced only within the `config/production.json`. So if we change it, it should replace the image URL to `https://androidmakers.fr/images/social-share.jpg`.

I tried on this first commit to do (2). Because it seems invalid anyway that we still have a config on the `hoverboard-master.web.app` url.

*Test*

I compile, it changes the index.html with the proper image url: `https://androidmakers.fr/images/social-share.jpg`.




