### PR TITLE
Update Deezer logo

### DIFF
--- a/images/logos/deezer.svg
+++ b/images/logos/deezer.svg
@@ -1,1 +1,65 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="800" width="1200" viewBox="-150 -47.8 1300 286.8"><g transform="translate(0 86.8)"><path d="M234.1 40.1c0 40.1 24.7 64.1 61.4 64.1 18.3 0 33.7-5.1 42.3-18.5v18.5h33.5v-191h-34.8v81.2C328.6-19 314-25 295.7-25c-35.8-.1-61.6 24.4-61.6 65.1zm103.5 0c0 22.9-15.6 37.2-34.3 37.2-19.4 0-34.3-14.3-34.3-37.2 0-23.3 15-37.9 34.3-37.9 18.7 0 34.3 14.8 34.3 37.9zm142 14.8c-4 14.8-14.1 22.2-30 22.2-18.5 0-33.7-11.2-34.1-31h87.7c1.1-4.9 1.6-10.1 1.6-15.8 0-35.5-24.2-55.5-59.9-55.5-38.1 0-64.3 27.1-64.3 63.9 0 41 28.9 65.6 68.9 65.6 30.2 0 50.7-12.6 59.7-37.7zm-64.1-32C418.8 8.6 430.7.2 445 .2c15.6 0 26.2 8.4 26.2 21.6l-.2 1.1zm193.2 32c-4 14.8-14.1 22.2-30 22.2-18.5 0-33.7-11.2-34.1-31h87.7c1.1-4.9 1.6-10.1 1.6-15.8 0-35.5-24.2-55.5-59.9-55.5-38.1 0-64.3 27.1-64.3 63.9 0 41 28.9 65.6 68.9 65.6 30.2 0 50.7-12.6 59.7-37.7zm-64.1-32C547.9 8.6 559.8.2 574.1.2c15.6 0 26.2 8.4 26.2 21.6l-.2 1.1zm212.1 81.5V72.9h-73.1l71.1-69.2v-28.8H642.2v30h68.7L640 74.4v30zm101.7-49.5c-4 14.8-14.1 22.2-30 22.2-18.5 0-33.7-11.2-34.1-31H882c1.1-4.9 1.6-10.1 1.6-15.8 0-35.5-24.2-55.5-59.9-55.5-38.1 0-64.3 27.1-64.3 63.9 0 41 28.9 65.6 68.9 65.6 30.2 0 50.7-12.6 59.7-37.7zm-64.1-32C797.6 8.6 809.5.2 823.8.2 839.4.2 850 8.6 850 21.8l-.2 1.1z"/><path fill-rule="evenodd" clip-rule="evenodd" fill="#40ab5d" d="M155.5-25.1h42.9V0h-42.9z"/><linearGradient gradientTransform="matrix(1.8318 0 0 -1.8318 381.813 477.953)" y2="255.826" x2="-111.943" y1="241.804" x1="-111.722" gradientUnits="userSpaceOnUse" id="a"><stop offset="0" stop-color="#358c7b"/><stop offset=".526" stop-color="#33a65e"/></linearGradient><path fill="url(#a)" fill-rule="evenodd" clip-rule="evenodd" d="M155.5 9.7h42.9v25.1h-42.9z"/><linearGradient gradientTransform="matrix(1.8318 0 0 -1.8318 381.813 477.953)" y2="235.917" x2="-99.772" y1="223.628" x1="-123.891" gradientUnits="userSpaceOnUse" id="b"><stop offset="0" stop-color="#222b90"/><stop offset="1" stop-color="#367b99"/></linearGradient><path fill="url(#b)" fill-rule="evenodd" clip-rule="evenodd" d="M155.5 44.5h42.9v25.1h-42.9z"/><linearGradient gradientTransform="matrix(1.8318 0 0 -1.8318 381.813 477.953)" y2="210.773" x2="-185.032" y1="210.773" x1="-208.432" gradientUnits="userSpaceOnUse" id="c"><stop offset="0" stop-color="#f90"/><stop offset="1" stop-color="#ff8000"/></linearGradient><path fill="url(#c)" fill-rule="evenodd" clip-rule="evenodd" d="M0 79.3h42.9v25.1H0z"/><linearGradient gradientTransform="matrix(1.8318 0 0 -1.8318 381.813 477.953)" y2="210.773" x2="-156.732" y1="210.773" x1="-180.132" gradientUnits="userSpaceOnUse" id="d"><stop offset="0" stop-color="#ff8000"/><stop offset="1" stop-color="#cc1953"/></linearGradient><path fill="url(#d)" fill-rule="evenodd" clip-rule="evenodd" d="M51.8 79.3h42.9v25.1H51.8z"/><linearGradient gradientTransform="matrix(1.8318 0 0 -1.8318 381.813 477.953)" y2="210.773" x2="-128.432" y1="210.773" x1="-151.832" gradientUnits="userSpaceOnUse" id="e"><stop offset="0" stop-color="#cc1953"/><stop offset="1" stop-color="#241284"/></linearGradient><path fill="url(#e)" fill-rule="evenodd" clip-rule="evenodd" d="M103.7 79.3h42.9v25.1h-42.9z"/><linearGradient gradientTransform="matrix(1.8318 0 0 -1.8318 381.813 477.953)" y2="210.773" x2="-100.16" y1="210.773" x1="-123.56" gradientUnits="userSpaceOnUse" id="f"><stop offset="0" stop-color="#222b90"/><stop offset="1" stop-color="#3559a6"/></linearGradient><path fill="url(#f)" fill-rule="evenodd" clip-rule="evenodd" d="M155.5 79.3h42.9v25.1h-42.9z"/><linearGradient gradientTransform="matrix(1.8318 0 0 -1.8318 381.813 477.953)" y2="233.464" x2="-127.508" y1="226.081" x1="-152.755" gradientUnits="userSpaceOnUse" id="g"><stop offset="0" stop-color="#cc1953"/><stop offset="1" stop-color="#241284"/></linearGradient><path fill="url(#g)" fill-rule="evenodd" clip-rule="evenodd" d="M103.7 44.5h42.9v25.1h-42.9z"/><linearGradient gradientTransform="matrix(1.8318 0 0 -1.8318 381.813 477.953)" y2="225.211" x2="-155.899" y1="234.334" x1="-180.965" gradientUnits="userSpaceOnUse" id="h"><stop offset=".003" stop-color="#fc0"/><stop offset="1" stop-color="#ce1938"/></linearGradient><path fill="url(#h)" fill-rule="evenodd" clip-rule="evenodd" d="M51.8 44.5h42.9v25.1H51.8z"/><linearGradient gradientTransform="matrix(1.8318 0 0 -1.8318 381.813 477.953)" y2="239.791" x2="-158.699" y1="257.754" x1="-178.165" gradientUnits="userSpaceOnUse" id="i"><stop offset=".003" stop-color="#ffd100"/><stop offset="1" stop-color="#fd5a22"/></linearGradient><path fill="url(#i)" fill-rule="evenodd" clip-rule="evenodd" d="M51.8 9.7h42.9v25.1H51.8z"/><path d="M966.1 19.6v3.7h33.9v-9.9c0-22.2-13.9-38.3-37.2-38.3-15 0-25.6 7.3-31.1 19.4v-19.4h-35v129.3h35V21.1c0-13.2 7.1-20.5 18-20.5 10 .1 16.4 9.5 16.4 19z"/></g></svg>
+<svg width="580" height="113" viewBox="0 0 580 113" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M335.461 94.9999C324.691 94.9999 315.831 88.5099 315.671 77.1099H366.671C367.339 74.0958 367.675 71.0173 367.671 67.93C367.671 47.34 353.581 34.2 332.841 34.2C310.671 34.2 295.471 51.4599 295.471 72.8299C295.471 96.5799 311.941 112.42 335.211 112.42C352.791 112.42 364.981 103.55 370.211 88.98L352.881 82.21C350.501 90.73 344.641 94.9999 335.461 94.9999ZM332.771 50.51C341.771 50.51 347.971 55.42 347.971 63.02L347.811 63.65H315.671C317.571 55.42 324.541 50.51 332.771 50.51Z" fill="white"/>
+<path d="M437.73 52.41V35.78H372.34V53.2H412.24L371.07 93.42V110.83H438.84V92.62H396.4L437.73 52.41Z" fill="white"/>
+<path d="M559.86 60.01C559.866 61.2709 559.782 62.5307 559.61 63.78H578.82C579.287 61.338 579.511 58.856 579.49 56.37C579.49 43.54 571.42 34.2 557.96 34.2C549.25 34.2 543.08 38.4799 539.91 45.4399V35.79H519.65V110.79H539.91V62.54C539.91 54.94 544.03 50.67 550.36 50.67C556.06 50.67 559.86 54.47 559.86 60.01Z" fill="white"/>
+<path d="M194.999 47.03C190.399 39.27 181.849 34.2 171.249 34.2C150.659 34.2 135.619 50.04 135.619 73.63C135.619 96.9 150.509 112.42 171.719 112.42C182.329 112.42 190.879 107.82 195.789 100.07V110.83H215.259V0H194.999V47.03ZM175.829 95.21C164.589 95.21 155.829 86.98 155.829 73.68C155.829 60.22 164.539 51.68 175.829 51.68C186.749 51.68 195.779 60.23 195.779 73.68C195.779 86.93 186.749 95.21 175.829 95.21Z" fill="white"/>
+<path d="M479.81 94.9999C469.04 94.9999 460.18 88.5099 460.02 77.1099H511.02C511.689 74.0958 512.024 71.0173 512.02 67.93C512.02 47.34 497.93 34.2 477.19 34.2C455.02 34.2 439.82 51.4599 439.82 72.8299C439.82 96.5799 456.29 112.42 479.56 112.42C497.14 112.42 509.33 103.55 514.56 88.98L497.22 82.21C494.85 90.73 489 94.9999 479.81 94.9999ZM477.12 50.51C486.12 50.51 492.32 55.42 492.32 63.02L492.16 63.65H460C461.92 55.42 468.88 50.51 477.12 50.51Z" fill="white"/>
+<path d="M260.63 94.9999C249.86 94.9999 241 88.5099 240.84 77.1099H291.84C292.497 74.0947 292.815 71.0157 292.79 67.93C292.79 47.34 278.7 34.2 257.96 34.2C235.79 34.2 220.59 51.4599 220.59 72.8299C220.59 96.5799 237.06 112.42 260.33 112.42C277.91 112.42 290.1 103.55 295.33 88.98L278.05 82.21C275.67 90.73 269.81 94.9999 260.63 94.9999ZM257.94 50.51C266.94 50.51 273.14 55.42 273.14 63.02L272.98 63.65H240.84C242.74 55.42 249.71 50.51 257.94 50.51Z" fill="white"/>
+<path d="M115.35 35.73H90.5195V50.22H115.35V35.73Z" fill="#29AB70"/>
+<path d="M115.35 55.9099H90.5195V70.3999H115.35V55.9099Z" fill="url(#paint0_linear)"/>
+<path d="M115.35 76.08H90.5195V90.57H115.35V76.08Z" fill="url(#paint1_linear)"/>
+<path d="M25.3398 96.26H0.509766V110.75H25.3398V96.26Z" fill="url(#paint2_linear)"/>
+<path d="M55.3398 96.26H30.5098V110.75H55.3398V96.26Z" fill="url(#paint3_linear)"/>
+<path d="M85.3495 96.26H60.5195V110.75H85.3495V96.26Z" fill="url(#paint4_linear)"/>
+<path d="M115.35 96.26H90.5195V110.75H115.35V96.26Z" fill="url(#paint5_linear)"/>
+<path d="M85.3495 76.08H60.5195V90.57H85.3495V76.08Z" fill="url(#paint6_linear)"/>
+<path d="M55.3398 76.08H30.5098V90.57H55.3398V76.08Z" fill="url(#paint7_linear)"/>
+<path d="M55.3398 55.9099H30.5098V70.3999H55.3398V55.9099Z" fill="url(#paint8_linear)"/>
+<path d="M335.461 94.9999C324.691 94.9999 315.831 88.5099 315.671 77.1099H366.671C367.339 74.0958 367.675 71.0173 367.671 67.93C367.671 47.34 353.581 34.2 332.841 34.2C310.671 34.2 295.471 51.4599 295.471 72.8299C295.471 96.5799 311.941 112.42 335.211 112.42C352.791 112.42 364.981 103.55 370.211 88.98L352.881 82.21C350.501 90.73 344.641 94.9999 335.461 94.9999ZM332.771 50.51C341.771 50.51 347.971 55.42 347.971 63.02L347.811 63.65H315.671C317.571 55.42 324.541 50.51 332.771 50.51Z" fill="black"/>
+<path d="M437.73 52.41V35.78H372.34V53.2H412.24L371.07 93.42V110.83H438.84V92.62H396.4L437.73 52.41Z" fill="black"/>
+<path d="M559.86 60.01C559.866 61.2709 559.782 62.5307 559.61 63.78H578.82C579.287 61.338 579.511 58.856 579.49 56.37C579.49 43.54 571.42 34.2 557.96 34.2C549.25 34.2 543.08 38.4799 539.91 45.4399V35.79H519.65V110.79H539.91V62.54C539.91 54.94 544.03 50.67 550.36 50.67C556.06 50.67 559.86 54.47 559.86 60.01Z" fill="black"/>
+<path d="M194.999 47.03C190.399 39.27 181.849 34.2 171.249 34.2C150.659 34.2 135.619 50.04 135.619 73.63C135.619 96.9 150.509 112.42 171.719 112.42C182.329 112.42 190.879 107.82 195.789 100.07V110.83H215.259V0H194.999V47.03ZM175.829 95.21C164.589 95.21 155.829 86.98 155.829 73.68C155.829 60.22 164.539 51.68 175.829 51.68C186.749 51.68 195.779 60.23 195.779 73.68C195.779 86.93 186.749 95.21 175.829 95.21Z" fill="black"/>
+<path d="M479.81 94.9999C469.04 94.9999 460.18 88.5099 460.02 77.1099H511.02C511.689 74.0958 512.024 71.0173 512.02 67.93C512.02 47.34 497.93 34.2 477.19 34.2C455.02 34.2 439.82 51.4599 439.82 72.8299C439.82 96.5799 456.29 112.42 479.56 112.42C497.14 112.42 509.33 103.55 514.56 88.98L497.22 82.21C494.85 90.73 489 94.9999 479.81 94.9999ZM477.12 50.51C486.12 50.51 492.32 55.42 492.32 63.02L492.16 63.65H460C461.92 55.42 468.88 50.51 477.12 50.51Z" fill="black"/>
+<path d="M260.63 94.9999C249.86 94.9999 241 88.5099 240.84 77.1099H291.84C292.497 74.0947 292.815 71.0157 292.79 67.93C292.79 47.34 278.7 34.2 257.96 34.2C235.79 34.2 220.59 51.4599 220.59 72.8299C220.59 96.5799 237.06 112.42 260.33 112.42C277.91 112.42 290.1 103.55 295.33 88.98L278.05 82.21C275.67 90.73 269.81 94.9999 260.63 94.9999ZM257.94 50.51C266.94 50.51 273.14 55.42 273.14 63.02L272.98 63.65H240.84C242.74 55.42 249.71 50.51 257.94 50.51Z" fill="black"/>
+<defs>
+<linearGradient id="paint0_linear" x1="104.55" y1="72.2999" x2="101.32" y2="53.9999" gradientUnits="userSpaceOnUse">
+<stop stop-color="#2C8C9D"/>
+<stop offset="0.04" stop-color="#298E9A"/>
+<stop offset="0.39" stop-color="#129C83"/>
+<stop offset="0.72" stop-color="#05A475"/>
+<stop offset="1" stop-color="#00A770"/>
+</linearGradient>
+<linearGradient id="paint1_linear" x1="90.1495" y1="89.84" x2="115.72" y2="76.81" gradientUnits="userSpaceOnUse">
+<stop stop-color="#2839BA"/>
+<stop offset="1" stop-color="#148CB3"/>
+</linearGradient>
+<linearGradient id="paint2_linear" x1="0.509766" y1="103.5" x2="25.3398" y2="103.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#F6A500"/>
+<stop offset="1" stop-color="#F29100"/>
+</linearGradient>
+<linearGradient id="paint3_linear" x1="30.5098" y1="103.5" x2="55.3398" y2="103.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#F29100"/>
+<stop offset="1" stop-color="#D12F5F"/>
+</linearGradient>
+<linearGradient id="paint4_linear" x1="60.5195" y1="103.5" x2="85.3495" y2="103.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#B4197C"/>
+<stop offset="1" stop-color="#472EAD"/>
+</linearGradient>
+<linearGradient id="paint5_linear" x1="90.5195" y1="103.5" x2="115.35" y2="103.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#2839BA"/>
+<stop offset="1" stop-color="#3072B7"/>
+</linearGradient>
+<linearGradient id="paint6_linear" x1="59.5395" y1="87.24" x2="86.3195" y2="79.41" gradientUnits="userSpaceOnUse">
+<stop stop-color="#B4197C"/>
+<stop offset="1" stop-color="#373AAC"/>
+</linearGradient>
+<linearGradient id="paint7_linear" x1="29.6398" y1="78.49" x2="56.2198" y2="88.16" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FFCB00"/>
+<stop offset="1" stop-color="#D12F5F"/>
+</linearGradient>
+<linearGradient id="paint8_linear" x1="32.6098" y1="53.6299" x2="53.2398" y2="72.6699" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FFCF00"/>
+<stop offset="1" stop-color="#ED743B"/>
+</linearGradient>
+</defs>
+</svg>


### PR DESCRIPTION
Due to an inset on the Deezer logo linked to Jean-Baptiste profil, the logo was displayed in a really tiny tiny format:
<img width="942" alt="Screenshot 2022-04-17 at 12 02 15" src="https://user-images.githubusercontent.com/4451893/163709869-146a7835-5afe-4a09-a962-eea31b327c2c.png">

To fix this, I use the `Deezer_Logo_RVB_Black.svg` logo version from Deezer logotypes resources: https://deezerbrand.com/d/9wmMErzrRuiH/brand-elements.