### PR TITLE
Remove english flag directly embedded in title

### DIFF
--- a/data/database/sessions.json
+++ b/data/database/sessions.json
@@ -239,7 +239,7 @@
         ]
     },
     "FTE-5493": {
-        "title": "The untold guide for making PoCs [English]",
+        "title": "The untold guide for making PoCs",
         "tags": [
             "Android Development"
         ],


### PR DESCRIPTION
Remove embedded "[English]" flag in session title:  "The untold guide for making PoCs [English]"