### PR TITLE
Add the wifi config in firestore

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -240,5 +240,9 @@ service cloud.firestore {
     match /rooms/{id} {
       allow read;
     }
+    
+    match /wifi/{id} {
+      allow read;
+    }
   }
 }


### PR DESCRIPTION
It used to be in Remote Config but the Remote Config cache TTL is way to long to be able to modify it if needed